### PR TITLE
Open a text file without specifying an encoding is an error

### DIFF
--- a/ilmsdump/__init__.py
+++ b/ilmsdump/__init__.py
@@ -239,11 +239,11 @@ class Client:
 
     async def ensure_authenticated(self, prompt: bool):
         try:
-            cred_file = open(self.cred_path)
+            cred_file = open(self.cred_path, encoding='utf-8')
         except FileNotFoundError:
             if prompt:
                 await self.interactive_login()
-                with open(self.cred_path, 'w') as file:
+                with open(self.cred_path, 'w', encoding='utf-8') as file:
                     print(
                         self.session.cookie_jar.filter_cookies(yarl.URL(LOGIN_STATE_URL))[
                             'PHPSESSID'
@@ -580,7 +580,9 @@ class Downloader:
                         item_children.append(child)
                         self.mark_total(child)
 
-                    with (self.client.get_dir_for(item) / 'meta.json').open('w') as file:
+                    with (self.client.get_dir_for(item) / 'meta.json').open(
+                        'w', encoding='utf-8'
+                    ) as file:
                         json.dump(
                             {
                                 **item.get_meta(),
@@ -843,7 +845,7 @@ class Announcement(Downloadable):
             for attachment in get_attachments(self, lxml.html.fromstring(attachment_raw_div)):
                 yield attachment
 
-        with (client.get_dir_for(self) / 'index.json').open('w') as file:
+        with (client.get_dir_for(self) / 'index.json').open('w', encoding='utf-8') as file:
             json.dump(body_json, file)
 
 
@@ -937,7 +939,7 @@ class Discussion(Downloadable):
                         parent=self,
                     )
 
-            with (client.get_dir_for(self) / 'index.json').open('w') as file:
+            with (client.get_dir_for(self) / 'index.json').open('w', encoding='utf-8') as file:
                 json.dump(body_json, file)
 
 

--- a/ilmsserve/__init__.py
+++ b/ilmsserve/__init__.py
@@ -78,7 +78,7 @@ class ApplicationContext:
         self.data_dir = pathlib.Path(data_dir)
 
     def open_base(self, typename, id, filename='meta.json'):
-        return (self.data_dir / typename / str(id) / filename).open()
+        return (self.data_dir / typename / str(id) / filename).open(encoding='utf-8')
 
     def get_name(self, name):
         return Object.from_name(self, name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import pickle
 import tempfile
 
@@ -23,7 +24,7 @@ def test_nothing_to_do(tempdir):
 
 def test_logout(tempdir):
     cred_file = os.path.join(tempdir, 'credentials.txt')
-    open(cred_file, 'w').close()
+    pathlib.Path(cred_file).touch()
 
     runner = click.testing.CliRunner(mix_stderr=False)
     result = runner.invoke(ilmsdump.main, ['--output-dir', tempdir, '--logout'])
@@ -34,7 +35,7 @@ def test_logout(tempdir):
 
 def test_anonymous(tempdir):
     cred_file = os.path.join(tempdir, 'credentials.txt')
-    open(cred_file, 'w').close()
+    pathlib.Path(cred_file).touch()
 
     runner = click.testing.CliRunner(mix_stderr=False)
     result = runner.invoke(ilmsdump.main, ['--output-dir', tempdir, '--anonymous'])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pytest
 
@@ -35,7 +36,7 @@ async def test_get_course_authentication_required(client):
 
 @pytest.mark.asyncio
 async def test_clear_credentials(client):
-    open(client.cred_path, 'w').close()
+    pathlib.Path(client.cred_path).touch()
     assert client.clear_credentials() is True
     assert not os.path.exists(client.cred_path)
 


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0597/

By changing the open encoding of ilmsserve, existing download shouldn't be broken. We have three types of downloads:

* metadata in `meta.json`: ensure_ascii is left on (default). OK.
* Attachments / Videos: binary, OK.
* Embedded pages generated with `lxml.html.tostring`; opened with `'wb'`. lxml says "_The encoding argument controls the output encoding (defaults to ASCII, with &#...; character references for any characters outside of ASCII)._" So OK.